### PR TITLE
Add Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM maven:3-eclipse-temurin-8
+
+WORKDIR /app
+
+ADD . .
+
+RUN mvn compile assembly:single
+
+ENTRYPOINT [ "java", "-jar", "/app/target/colchain.jar", "/app/config.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,5 @@ ADD . .
 
 RUN mvn compile assembly:single
 
-ENTRYPOINT [ "java", "-jar", "/app/target/colchain.jar", "/app/config.json" ]
+ENTRYPOINT [ "java", "-jar", "/app/target/colchain.jar" ]
+CMD [ "/app/config.json" ]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ To deploy in an application server, use the WAR file. Create an `config.json` co
 ### Setup
 Once the node is started, go to the web interface by opening a Web browser and navigating to the URL, e.g., `http://colchain.org:8080/`. Enter the path to the config file in the Web interface (1st form from the top), e.g., `/path/to/config.json` and hit `Initiate`.
 For experimental setup of a node, refer to [Running Experiments](#running-experiments).
+
+### Or deploy with docker
+
+Edit the `config.json` file at the root of this repository.
+
+Start the ColChain node on http://localhost:8080 using:
+```bash
+docker compose up
+```
+
 # Status
 ColChain is currently implemented as a prototype used for experiments in the ColChain paper. We are working on creating making the following features available in ColChain:
 * Different RDF compression techniques

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ ColChain is a new unstructured Peer-to-Peer architecture for sharing and queryin
 	* [Build](#build)
 	* [Deploy](#deploy)
 	* [Setup](#setup)
+	* [Docker](#docker)
 * [Status](#status)
 * [Running Experiments](#running-experiments)
 # Abstract
@@ -68,14 +69,17 @@ To deploy in an application server, use the WAR file. Create an `config.json` co
 Once the node is started, go to the web interface by opening a Web browser and navigating to the URL, e.g., `http://colchain.org:8080/`. Enter the path to the config file in the Web interface (1st form from the top), e.g., `/path/to/config.json` and hit `Initiate`.
 For experimental setup of a node, refer to [Running Experiments](#running-experiments).
 
-### Or deploy with docker
+### Docker
 
-Edit the `config.json` file at the root of this repository.
+Alternatively you can use docker to deploy a ColChain node.
 
-Start the ColChain node on http://localhost:8080 using:
-```bash
-docker compose up
-```
+1. Edit the `config.json` file at the root of this repository.
+
+2. Start the ColChain node on http://localhost:8080 using:
+
+   ```bash
+   docker compose up
+   ```
 
 # Status
 ColChain is currently implemented as a prototype used for experiments in the ColChain paper. We are working on creating making the following features available in ColChain:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,21 @@
+{
+    "title": "My ColChain Client",
+    "datasourcetypes": {
+        "HdtDatasource": "org.linkeddatafragments.datasource.hdt.HdtDataSourceType"
+    },
+
+    "datastore":"datastore/",
+    "address":"http://localhost:8080",
+    "prefixes": {
+        "rdf":         "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        "rdfs":        "http://www.w3.org/2000/01/rdf-schema#",
+        "xsd":         "http://www.w3.org/2001/XMLSchema#",
+        "dc":          "http://purl.org/dc/terms/",
+        "foaf":        "http://xmlns.com/foaf/0.1/",
+        "dbpedia":     "http://dbpedia.org/resource/",
+        "dbpedia-owl": "http://dbpedia.org/ontology/",
+        "dbpprop":     "http://dbpedia.org/property/",
+        "hydra":       "http://www.w3.org/ns/hydra/core#",
+        "void":        "http://rdfs.org/ns/void#"
+    }
+  }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+
+  colchain:
+    build: .
+    ports:
+      - 8080:8080
+    volumes:
+      - ./config.json:/app/config.json


### PR DESCRIPTION
Added a simple `Dockerfile` and `docker-compose.yml` to easily build and deploy ColChain using docker

I also added the basic instructions to start ColChain with `docker compose` in the readme

It works and deploy the ColChain UI on http://localhost:8080, but we will probably need to improve the setup to make it easier to configure